### PR TITLE
Update to version 1.5.0: Add bounded channel implementations, `Go<T>`…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Console.WriteLine("Channel consumed. Program finished.");
 
 #### **Implicit Channel (Shorthand)**
 Concur provides a convenient shorthand that creates and returns a channel for you.
+By default, `Go<T>` uses `DefaultChannel<T>`, but you can supply `channelFactory` to choose a different implementation.
 
 ```csharp
 // Go<T> creates and returns a readable channel.
@@ -117,8 +118,37 @@ await foreach (var number in numbers)
 }
 ```
 
+For bounded workloads, pick the channel that matches your reader pattern:
+
+```csharp
+// Many producers, one consumer.
+var singleReaderNumbers = Go<int>(
+    async writer =>
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            await writer.WriteAsync(i);
+        }
+        await writer.CompleteAsync();
+    },
+    channelFactory: () => new MpscBoundedChannel<int>(capacity: 64));
+
+// Many producers, many consumers.
+var multiReaderNumbers = Go<int>(
+    async writer =>
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            await writer.WriteAsync(i);
+        }
+        await writer.CompleteAsync();
+    },
+    channelFactory: () => new MpmcBoundedChannel<int>(capacity: 64, shardCount: 4));
+```
+
 #### **Bounded Channels**
 By default, channels are unbounded. You can specify a capacity to create a bounded channel. A producer writing to a full bounded channel will block asynchronously until a consumer makes space.
+Use `MpscBoundedChannel<T>` when you have one consumer, and `MpmcBoundedChannel<T>` when multiple consumers will compete for work.
 
 ```csharp
 // Create a channel that can only hold 2 items at a time.

--- a/src/Concur/Concur.csproj
+++ b/src/Concur/Concur.csproj
@@ -4,24 +4,18 @@
     <TargetFramework>$(FrameworkVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <Description>A lightweight C# library providing Go-inspired concurrency patterns for .NET applications.</Description>
     <PackageProjectUrl>https://github.com/Desz01ate/Concur</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Desz01ate/Concur</RepositoryUrl>
-    <PackageReleaseNotes>
-## What's New in 1.4.0
+    <PackageReleaseNotes><![CDATA[
+## What's New in 1.5.0
 
 ### Features
-- Added degree of parallelism support via `GoOptions`
-- Added extra constructors for `WaitGroup`
-
-### Performance
-- Replaced `WaitGroup` locking with lock-free CAS for reduced contention
-- Inlined `Go()` fast/slow paths, removing `ExecuteWithConcurrencyLimitAsync`
-
-### Bug Fixes
-- Fixed race condition in `WaitGroup` around `TaskCompletionSource` access
-    </PackageReleaseNotes>
+- Added `Go<T>` channel factory support so callers can choose the concrete `IChannel<T>` implementation
+- Added `MpscBoundedChannel<T>` for bounded multi-producer, single-consumer workloads
+- Added `MpmcBoundedChannel<T>` for bounded multi-producer, multi-consumer workloads
+    ]]></PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
… channel factory support, and enhance README with usage examples.